### PR TITLE
Fix links in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,8 +1,7 @@
 <footer class="colophon">
   <ul class="quick-links">
     <li><a href="http://getbootstrap.com">View the docs</a></li>
-    <li><a href="https://github.com/twitter/bootstrap/issues?state=open">Submit issues</a></li>
-    <li><a href="https://github.com/twitter/bootstrap/wiki">Roadmap and changelog</a></li>
+    <li><a href="https://github.com/twbs/bootstrap/issues?state=open">Submit issues</a></li>
   </ul>
   <ul class="quick-links">
     <li>


### PR DESCRIPTION
I've updated the link in the footer so it uses the new repo URL.

I removed the Roadmap and changelog  link as these don't seem to exist anymore.
