### PR TITLE
[WIP] Switch to jekyll-paginate-v2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 group :development, :test do
   gem 'jekyll', '~> 3.8.5'
   gem 'jekyll-feed', '~> 0.12.1'
-  gem 'jekyll-paginate', '~> 1.1.0'
+  gem 'jekyll-paginate-v2', '~> 2.0.0'
   gem 'jekyll-redirect-from', '~> 0.15.0'
   gem 'jekyll-seo-tag', '~> 2.6.1'
   gem 'jekyll-sitemap', '~> 1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.12.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-paginate (1.1.0)
+    jekyll-paginate-v2 (2.0.0)
+      jekyll (~> 3.0)
     jekyll-redirect-from (0.15.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
@@ -72,7 +73,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.5)
   jekyll-feed (~> 0.12.1)
-  jekyll-paginate (~> 1.1.0)
+  jekyll-paginate-v2 (~> 2.0.0)
   jekyll-redirect-from (~> 0.15.0)
   jekyll-seo-tag (~> 2.6.1)
   jekyll-sitemap (~> 1.3.1)

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,14 @@ future:         true
 permalink:      pretty
 
 # Pagination
-paginate:       5
+pagination:
+  enabled:      true
+  per_page:     5
+  permalink:    "/page:num/"
+  title:        "Archive"
+  limit:        0
+  sort_field:   "date"
+  sort_reverse: true
 
 # Sass converter configuration
 sass:
@@ -44,7 +51,7 @@ defaults:
 # Gems
 plugins:
   - jekyll-feed
-  - jekyll-paginate
+  - jekyll-paginate-v2
   - jekyll-redirect-from
   - jekyll-seo-tag
   - jekyll-sitemap

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 slug: home
+pagination:
+  enabled: true
 redirect_from:
   - /2017/06/14/introducing-bootstrap-jobs/
 ---


### PR DESCRIPTION
jekyll-paginate is unmaintained and has quite a few bugs.

TODO:

- [ ] figure out why the paginated pages are not in the sitemap; upstream issue, waiting for a new release
- [x] fix paginated pages title
- [ ] use trails?

Fixes #83 