### PR TITLE
Lazyload all post images.

### DIFF
--- a/_posts/2015-08-19-bootstrap-4-alpha.md
+++ b/_posts/2015-08-19-bootstrap-4-alpha.md
@@ -10,7 +10,7 @@ Bootstrap 4 has been a massive undertaking that touches nearly every line of cod
 
 ## What's new
 
-[![Bootstrap 4 alpha](/assets/img/2015/bs4-alpha.png)](https://v4-alpha.getbootstrap.com/)
+[![Bootstrap 4 alpha](/assets/img/2015/bs4-alpha.png){: class="lazy" }](https://v4-alpha.getbootstrap.com/)
 
 There are a ton of major changes to Bootstrap and it's impossible to cover them all in detail here, so here are some of our favorite highlights:
 
@@ -53,7 +53,7 @@ When we shipped Bootstrap 3, we immediately discontinued all support for v2.x, c
 
 In addition to shipping the first Bootstrap 4 alpha today, we're also launching our latest side project, [Official Bootstrap Themes]({{ site.themes }}).
 
-[![Official Bootstrap Themes](/assets/img/2015/bs-themes.png)]({{ site.themes }})
+[![Official Bootstrap Themes](/assets/img/2015/bs-themes.png){: class="lazy" }]({{ site.themes }})
 
 We've talked about building premium themes for Bootstrap since our earliest releases, but never quite found the time or ideal approach until earlier this year. We've poured hundreds of hours into these themes and consider them to be much more than traditional re-skins of Bootstrap. They've very much their own toolkits, just like Bootstrap.
 

--- a/_posts/2016-07-27-bootstrap-4-alpha-3.md
+++ b/_posts/2016-07-27-bootstrap-4-alpha-3.md
@@ -26,7 +26,7 @@ These changes are available in our standard grid, as well as our flexbox grid. M
 
 ## Flexbox
 
-<img alt="Flexbox auto-layout" src="/assets/img/2016/07/flex-cols.png" style="padding: 4px; border: 1px solid #eee;">
+<img alt="Flexbox auto-layout" src="/assets/img/2016/07/flex-cols.png" class="lazy" style="padding: 4px; border: 1px solid #eee;">
 
 Flexbox mode has been updated across the board in Alpha 3, starting from the grid system (it uses the same variable and the updated Sass mixins) and moving through our utilities and components.
 
@@ -38,7 +38,7 @@ Flexbox mode has been updated across the board in Alpha 3, starting from the gri
 
 ## Forms
 
-<img alt="Form validation states" src="/assets/img/2016/07/forms.png" style="padding: 4px; border: 1px solid #eee;">
+<img alt="Form validation states" src="/assets/img/2016/07/forms.png" class="lazy" style="padding: 4px; border: 1px solid #eee;">
 
 Forms saw a ton of activity early on in Alpha 3's development. Documentation, class names, layout options, and validation styles have all been drastically improved.
 

--- a/_posts/2017-01-06-bootstrap-4-alpha-6.md
+++ b/_posts/2017-01-06-bootstrap-4-alpha-6.md
@@ -50,7 +50,7 @@ Padding for grid containers can now be configured across breakpoints with the ne
 
 As mentioned in our last release, the Alpha 5 navbar was a little half baked. This time around, we're completely baked. No, but seriously, the navbar has been rewritten to provide better built-in responsive behaviors and improved layout customization thanks to our move to flexbox.
 
-[![Bootstrap 4 navbars](/assets/img/2017/alpha6-navbar.png)](https://v4-alpha.getbootstrap.com/components/navbar/)
+[![Bootstrap 4 navbars](/assets/img/2017/alpha6-navbar.png){: class="lazy" }](https://v4-alpha.getbootstrap.com/components/navbar/)
 
 Here's the rundown on what's changed:
 

--- a/_posts/2017-08-10-bootstrap-4-beta.md
+++ b/_posts/2017-08-10-bootstrap-4-beta.md
@@ -30,7 +30,7 @@ Okay, phew, want to learn even more? Keep reading, or jump right to [those brand
 
 Bootstrap 4 has been sporting a slightly updated look throughout our alpha releases, but it wasn't until recently that we gave the docs and our components a refresh, too.
 
-[![Bootstrap 4 beta docs](/assets/img/2017/bootstrap-4-beta.png)]({{ site.main }}/)
+[![Bootstrap 4 beta docs](/assets/img/2017/bootstrap-4-beta.png){: class="lazy" }]({{ site.main }}/)
 
 In addition to a new color palette and new systems fonts, we have a brand new layout for our documentation. New with this beta is an amazing search form powered by Algolia's [DocSearch](https://community.algolia.com/docsearch/), an improved page layout with stickied navbar and sidebar, and a new table of contents.
 

--- a/_posts/2017-10-19-bootstrap-4-beta-2.md
+++ b/_posts/2017-10-19-bootstrap-4-beta-2.md
@@ -16,7 +16,7 @@ We've pushed over 500 commits in our two months, so we have a few changes since 
 
 ### Improved theming
 
-[![Bootstrap Theming docs page](/assets/img/2017/v4-beta2-theming-docs.png)]({{ site.main }}/docs/4.0/getting-started/theming/)
+[![Bootstrap Theming docs page](/assets/img/2017/v4-beta2-theming-docs.png){: class="lazy" }]({{ site.main }}/docs/4.0/getting-started/theming/)
 
 We have a brand [new Theming docs page]({{ site.main }}/docs/4.0/getting-started/theming/) to replace our old Options page (we'll automatically redirect folks from the old page). This new page delves into the structure of our Sass files, default variables and customizing them, maps and loops we use, functions, colors, and of course or global Sass options. It also includes a new section to explain how we build our components via Sass maps and loops, specifically our modifier classes (e.g., `.btn-danger`).
 
@@ -28,11 +28,11 @@ In addition to the documentation changes, we've made a few CSS changes to improv
 
 Lastly, our `$enable-shadows` and `$enable-gradients` Sass variables have finally been updated and integrated into several of our components. Now, when you enable those variables (both are `false` by default) and recompile, you'll see subtle gradients and shadows across alerts, buttons, carousels, custom form controls, and dropdown items.
 
-![Themed buttons](/assets/img/2017/v4-beta2-buttons.png)
+![Themed buttons](/assets/img/2017/v4-beta2-buttons.png){: class="lazy" }
 
 And when you use `$enable-gradients`, you'll enable the new `.bg-gradient-` utilities (disabled by default) for use in navbars and more.
 
-![Themed backgrounds](/assets/img/2017/v4-beta2-bgs.png)
+![Themed backgrounds](/assets/img/2017/v4-beta2-bgs.png){: class="lazy" }
 
 Check it out and please share any feedback in an issue.
 

--- a/_posts/2018-01-18-bootstrap-4.md
+++ b/_posts/2018-01-18-bootstrap-4.md
@@ -32,7 +32,7 @@ In addition, we've made plenty of improvements to reusing and extending variable
 
 Nearly every example has been overhauled for our stable v4 release. We've removed a couple outdated examples, added brand new ones, and really overhauled a few others.
 
-[![Bootstrap examples](/assets/img/2018/01/examples.png)]({{ site.main }}/docs/4.0/examples/)
+[![Bootstrap examples](/assets/img/2018/01/examples.png){: class="lazy" }]({{ site.main }}/docs/4.0/examples/)
 
 Here's the rundown of changes to each:
 

--- a/_posts/2018-02-21-new-bootstrap-themes.md
+++ b/_posts/2018-02-21-new-bootstrap-themes.md
@@ -8,7 +8,7 @@ Just over a month ago, we shipped the long awaited Bootstrap 4 stable release. W
 
 ## 10 new themes
 
-[![Bootstrap themes grid](/assets/img/2018/02/themes-grid.png)]({{ site.themes }})
+[![Bootstrap themes grid](/assets/img/2018/02/themes-grid.png){: class="lazy" }]({{ site.themes }})
 
 Over the last several months, we've been hard at work with theme creators to build the best themes for you. When we created our original three Bootstrap themes, our goal was to provide the best themes, build tools, documentation, and support to everyone building with Bootstrap. With today's update, we're adding 10 new themes to the mix from a global community of designers and developers.
 

--- a/_posts/2018-12-21-bootstrap-4-2-1.md
+++ b/_posts/2018-12-21-bootstrap-4-2-1.md
@@ -16,7 +16,7 @@ Keep reading for highlights and some insight into how we're getting to v4.3 quic
 
 Here are the highlights of what's new and updated in v4.2.1.
 
-![Bootstrap toasts](/assets/img/2018/12/toasts.png)
+![Bootstrap toasts](/assets/img/2018/12/toasts.png){: class="lazy" }
 
 - **New:** Added a new [spinner loading component]({{ site.main }}/docs/4.2/components/spinners/).
 - **New:** Added new [toast component]({{ site.main }}/docs/4.2/components/toasts/) for displaying notifications.

--- a/_posts/2019-02-11-bootstrap-4-3-0.md
+++ b/_posts/2019-02-11-bootstrap-4-3-0.md
@@ -32,7 +32,7 @@ Checkout the full [v4.3.0 ship list](https://github.com/twbs/bootstrap/issues/27
 
 ## Introducing responsive font sizes
 
-![Responsive font-sizes](/assets/img/2019/02/rfs.png)
+![Responsive font-sizes](/assets/img/2019/02/rfs.png){: class="lazy" }
 
 Our biggest new addition to Bootstrap in v4.3 is responsive font sizes, a [new project in the Bootstrap GitHub org](https://github.com/twbs/rfs) to automate calculate an appropriate `font-size` based on the dimensions of a visitor's device or browser viewport. Here's how it works:
 

--- a/_posts/2019-11-26-bootstrap-icons.md
+++ b/_posts/2019-11-26-bootstrap-icons.md
@@ -6,11 +6,11 @@ video: eM8Ss28zjcE
 
 Say hello to [Bootstrap Icons](https://icons.getbootstrap.com/), our very first icon set that's designed entirely by our team and open sourced for everyone to use, with or without Bootstrap. It's still in alpha, but we're incredibly excited to share it with y'all ahead of our v5 alpha.
 
-[![Bootstrap Icons docs](/assets/img/2019/11/bi-docs.png)](https://icons.getbootstrap.com/)
+[![Bootstrap Icons docs](/assets/img/2019/11/bi-docs.png){: class="lazy" }](https://icons.getbootstrap.com/)
 
 For the longest time, I've wanted to design an icon set to better lean how to better draw with different pen tools and to better understand SVGs. In the last several months I've used a few different applications, done nearly five style iterations, and finally settled on a single direction. The result? Over 200 icons to start.
 
-<img src="/assets/img/2019/11/bi-icons.png" alt="Bootstrap Icons full list" width="300" style="margin: 0 auto;">
+<img src="/assets/img/2019/11/bi-icons.png" alt="Bootstrap Icons full list" class="lazy" width="300" style="margin: 0 auto;">
 
 I've designed these initial icons in Figma and exported them as SVGs. The plan is to share that Figma file publicly once it's cleaned up and the icon set is  more stable. While Bootstrap Icons are first and foremost designed to work with Bootstrap's components, they can be used anywhere. They're an entirely [separate project](https://github.com/twbs/icons) and package from Bootstrap, so you can easily use them in any project, or use any other icon set alongside Bootstrap's CSS and JavaScript.
 

--- a/_posts/2019-12-14-bootstrap-icons-alpha2.md
+++ b/_posts/2019-12-14-bootstrap-icons-alpha2.md
@@ -10,7 +10,7 @@ There's a brand new update of Bootstrap Icons today with our second alpha releas
 
 With over 120 new and updated icons, this is likely going to be our largest update before we our first stable release. We have some renamed icons, fixed bugs, new tools icons, new typography icons, tons of new arrows, and so much more.
 
-[![New icons in Alpha 2](/assets/img/2019/12/bootstrap-icons-alpha2-new.png)](https://icons.getbootstrap.com/)
+[![New icons in Alpha 2](/assets/img/2019/12/bootstrap-icons-alpha2-new.png){: class="lazy" }](https://icons.getbootstrap.com/)
 
 ## Highlights
 

--- a/_posts/2020-03-19-bootstrap-icons-alpha-3.md
+++ b/_posts/2020-03-19-bootstrap-icons-alpha-3.md
@@ -12,7 +12,7 @@ We've cleaned up existing icons, created new permalink pages for each and every 
 
 I've added 221 new icons in our third alpha, the most ever in an alpha release thus far. And while I was drawing all these new awesome icons, I also cleaned up the existing ones by changing their `viewBox` size and redrew many to ensure more pixel perfect icons.
 
-![All Bootstrap Icons](/assets/img/2020/03/bootstrap-icons-alpha3-all.png)
+![All Bootstrap Icons](/assets/img/2020/03/bootstrap-icons-alpha3-all.png){: class="lazy" }
 
 Why change the `viewBox`? In the first two alphas, I was drawing icons on 20x20 artboards in Figma. This seemed like a good idea, but every icon was roughly 16x16, so it ended up being dead space. Now, every icon has been updated to eliminate the 2px inner padding, making the `viewBox`s `0 0 16 16` instead of `0 0 20 20`.
 
@@ -24,7 +24,7 @@ Looking for a particular icon, but don't want to download the entire project to 
 
 From the Bootstrap Icons homepage, click any icon and you'll be taken to a page dedicated to just that icon. It features the icon in various sizes and renders the source code like you're used to seeing in Bootstrap's docs.
 
-![Bootstrap Icons permalink](/assets/img/2020/03/bootstrap-icons-alpha3-permalink.png)
+![Bootstrap Icons permalink](/assets/img/2020/03/bootstrap-icons-alpha3-permalink.png){: class="lazy" }
 
 Since this is still an alpha, some features are still missing from our docs. This includes unlinked tags, no category listing, and no copy to clipboard. I hope to see those added before our stable v1.0.0 release. PRs are very much welcome if you'd like to contribute!
 


### PR DESCRIPTION
Use kramdown's Inline Attribute Lists to add the class `lazy`.

Since we always have a video in each post, any images come after that and they are out of the critical rendering path.