### PR TITLE
Update Bootstrap version references to v4.5.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,8 @@ sass:
 host:           localhost # same as default value '127.0.0.1' but reads better
 
 # Links
-current_version: "4.4.1"
-docs_version:    "4.4"
+current_version: "4.5.0"
+docs_version:    "4.5"
 
 main:            "https://getbootstrap.com"
 github_org:      "https://github.com/twbs"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta name="author" content="{{ site.authors }}">
     <link href="https://gmpg.org/xfn/11" rel="profile">
 
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link href="/assets/css/style.css" rel="stylesheet">
 
     {% include favicons.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta name="author" content="{{ site.authors }}">
     <link href="https://gmpg.org/xfn/11" rel="profile">
 
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link href="/assets/css/style.css" rel="stylesheet">
 
     {% include favicons.html %}


### PR DESCRIPTION
I noticed the docs links were still pointing to the v4.4 docs/stylesheet. This should fix that.