### PR TITLE
Update Bootstrap current_version variable in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ sass:
 host:           localhost # same as default value '127.0.0.1' but reads better
 
 # Links
-current_version: "4.5.0"
+current_version: "4.5.2"
 docs_version:    "4.5"
 
 main:            "https://getbootstrap.com"


### PR DESCRIPTION
The blog is using Bootstrap v4.5.2 CSS but the footer says 4.5.0 - updating here will fix that.