### PR TITLE
CI: add `if-no-files-found: error`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           name: docs
           path: ./_site/
+          if-no-files-found: error
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will make the upload-artifact action to error out instead of issuing a warning