### PR TITLE
Update posts to move author to metadata

### DIFF
--- a/src/_includes/author-info.html
+++ b/src/_includes/author-info.html
@@ -1,8 +1,12 @@
-{% assign author = post.author | default: page.author -%}
+{% comment -%}
+  Accepts one param, "do_lazyload"
+{%- endcomment-%}
+
+{%- assign author = post.author | default: page.author -%}
 {%- assign date = post.date | default: page.date -%}
 <div class="d-flex align-items-center mb-4 text-muted author-info">
   <a class="d-flex align-items-center text-muted text-decoration-none" href="https://github.com/{{ author }}" target="_blank" rel="noopener">
-    <img class="mb-0 mr-2" src="https://github.com/{{ author }}.png" alt="" width="32" height="32">
+    <img class="mb-0 mr-2" src="https://github.com/{{ author }}.png" alt="" width="32" height="32"{% if include.do_lazyload == true %} loading="lazy"{% endif %}>
     <span>@{{ author }}</span>
   </a>
   <span class="d-flex align-items-center ml-3">

--- a/src/_includes/author-info.html
+++ b/src/_includes/author-info.html
@@ -9,7 +9,7 @@
     <img class="mb-0 mr-2" src="https://github.com/{{ author }}.png" alt="" width="32" height="32"{% if include.do_lazyload == true %} loading="lazy"{% endif %}>
     <span>@{{ author }}</span>
   </a>
-  <span class="d-flex align-items-center ml-3">
+  <span class="d-flex align-items-center ml-3" title="{{ date | date_to_rfc822 }}">
     {% include icons/calendar-event.svg class="mr-2" width="24" height="24" %}
     {{ date | date: '%B %d, %Y' }}
   </span>

--- a/src/_includes/author-info.html
+++ b/src/_includes/author-info.html
@@ -1,0 +1,12 @@
+{% assign author = post.author | default: page.author -%}
+{%- assign date = post.date | default: page.date -%}
+<div class="d-flex align-items-center mb-4 text-muted author-info">
+  <a class="d-flex align-items-center text-muted text-decoration-none" href="https://github.com/{{ author }}" target="_blank" rel="noopener">
+    <img class="mb-0 mr-2" src="https://github.com/{{ author }}.png" alt="" width="32" height="32">
+    <span>@{{ author }}</span>
+  </a>
+  <span class="d-flex align-items-center ml-3">
+    {% include icons/calendar-event.svg class="mr-2" width="24" height="24" %}
+    {{ date | date: '%B %d, %Y' }}
+  </span>
+</div>

--- a/src/_includes/icons/calendar-event.svg
+++ b/src/_includes/icons/calendar-event.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="{{ include.width }}" height="{{ include.height }}" class="{{ include.class }}" viewBox="0 0 16 16" role="img" fill="currentColor">
+  <path d="M11 6.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/>
+  <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
+</svg>

--- a/src/_layouts/post.html
+++ b/src/_layouts/post.html
@@ -5,16 +5,7 @@ layout: default
 <div class="posts-container px-3 mx-auto my-5">
   <div class="post">
     <h1 class="post-title fw-500">{{ page.title }}</h1>
-    <div class="d-flex align-items-center mb-4 text-muted">
-      <a class="d-flex align-items-center text-muted text-decoration-none" href="https://github.com/{{ page.author }}" target="_blank" rel="noopener">
-        <img class="mb-0 mr-2" src="https://github.com/{{ page.author }}.png" width="32" height="32" alt="">
-        <span>@{{ page.author }}</span>
-      </a>
-      <span class="d-flex align-items-center ml-3">
-        {% include icons/calendar-event.svg class="mr-2" width="24" height="24" %}
-        {{ page.date | date: '%B %d, %Y' }}
-      </span>
-    </div>
+    {%- include author-info.html -%}
 
     {%- if page.video -%}
     {%- include video.html -%}

--- a/src/_layouts/post.html
+++ b/src/_layouts/post.html
@@ -5,7 +5,16 @@ layout: default
 <div class="posts-container px-3 mx-auto my-5">
   <div class="post">
     <h1 class="post-title fw-500">{{ page.title }}</h1>
-    <span class="post-date">{{ page.date | date_to_string }}</span>
+    <div class="d-flex align-items-center mb-4 text-muted">
+      <a class="d-flex align-items-center text-muted text-decoration-none" href="https://github.com/{{ page.author }}" target="_blank" rel="noopener">
+        <img class="mb-0 mr-2" src="https://github.com/{{ page.author }}.png" width="32" height="32" alt="">
+        <span>@{{ page.author }}</span>
+      </a>
+      <span class="d-flex align-items-center ml-3">
+        {% include icons/calendar-event.svg class="mr-2" width="24" height="24" %}
+        {{ page.date | date: '%B %d, %Y' }}
+      </span>
+    </div>
 
     {%- if page.video -%}
     {%- include video.html -%}

--- a/src/_posts/2012/2012-03-22-combining-badges-less-and-labels-less-in-2-0-3.md
+++ b/src/_posts/2012/2012-03-22-combining-badges-less-and-labels-less-in-2-0-3.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Combining badges.less and labels.less in 2.0.3
+author: mdo
 ---
 
 For one reason or another, in 2.0.2 we made badges have separate LESS files. The CSS is 95% the same, but we knew that some folks might need one or the other, or even both. With [2.0.3](https://github.com/twbs/bootstrap/issues?milestone=10&q=is%3Aopen), we'll be simplifying some of those styles into a single .less file and scoping the `:hover` state to anchors only.

--- a/src/_posts/2012/2012-03-22-coming-up-in-bootstrap.md
+++ b/src/_posts/2012/2012-03-22-coming-up-in-bootstrap.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Coming up in Bootstrap
+author: mdo
 ---
 
 We've been mum on the next few releases for Bootstrap the last couple weeks, and with good reason: both Jacob and I have been super busy at work and we're uncertain of what features to add next. That said, we know we have some bugs and docs fixes to make and know we can slip in a few small features if time allows. I've updated [the roadmap](https://github.com/twbs/bootstrap/wiki/Roadmap) to reflect the last two releases and a general outline for the next two.

--- a/src/_posts/2012/2012-03-22-what-up-nerds.md
+++ b/src/_posts/2012/2012-03-22-what-up-nerds.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: What up, nerds?
+author: mdo
 ---
 
 Welcome one and all to the new, official Twitter Bootstrap blog. From now on, Jacob and I will be posting info on new releases, documentation changes, great examples of folks using Bootstrap, and more. Stay tuned for our first post on the next two updates for the project.

--- a/src/_posts/2012/2012-03-30-25000.md
+++ b/src/_posts/2012/2012-03-30-25000.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "25,000"
+author: mdo
 ---
 
 Earlier today [Bootstrap]({{ site.main }}/) passed 25,000 watchers on GitHub. For the last few months it has been the most watched project and continues to grow at an alarming rate. In fact, I recall writing about [8,700 watchers back in October](https://markdotto.com/2011/10/28/floored/). Jacob and I are still both in awe of how this former internal pet project has grown into one of the most popular front-end frameworks on the Web.
@@ -12,7 +13,3 @@ Thank you. *Really*, **thank you.**
 And a special thanks to the 119 contributors (not including Jacob or myself) who have committed code to Bootstrap. Without you guys, a lot of this wouldn't be possible.
 
 Here's to the next 25,000!
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [@fat](https://twitter.com/fat)

--- a/src/_posts/2012/2012-04-14-bootstraps-first-international-release.md
+++ b/src/_posts/2012/2012-04-14-bootstraps-first-international-release.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap's first intercontinental release
+author: mdo
 ---
 
 As you may have heard, Jacob and I are [heading to London in a week to talk Bootstrap](https://ukengopenhouse.eventbrite.com/)—and we're pretty stoked about it! The event is already sold out, but we'll be there for a few days to be sure to chat and hang with folks in the area.

--- a/src/_posts/2012/2012-04-15-help-test-bootstrap-2-0-3.md
+++ b/src/_posts/2012/2012-04-15-help-test-bootstrap-2-0-3.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Help test Bootstrap 2.0.3
+author: mdo
 ---
 
 Our next release, [2.0.3](https://github.com/twbs/bootstrap/issues?milestone=10&q=is%3Aopen), is almost ready to rock, but we need your help to get the finish line in the best shape possible. Similar to what we did for the big 2.0 launch, we're asking for the community's help in testing out the release's work-in-progress branch. We have a ton of bug fixes—another 80 or so since 2.0.2—and want to have the highest quality release we can.

--- a/src/_posts/2012/2012-04-19-bootstrap-jshint-and-recess.md
+++ b/src/_posts/2012/2012-04-19-bootstrap-jshint-and-recess.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap, JSHint, and Recess
+author: mdo
 ---
 
 This last week we've added two new developer tools to the Bootstrap tool chain and I wanted to take a minute to let you know a little bit more about what they are, why we've added them, and why it matters.

--- a/src/_posts/2012/2012-04-24-bootstrap-2-0-3-released.md
+++ b/src/_posts/2012/2012-04-24-bootstrap-2-0-3-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.0.3 released
+author: mdo
 ---
 
 Today we're releasing [Bootstrap 2.0.3]({{ site.main }}/), another bugfix release that aims to squash as many regressions and documentation inaccuracies as possible. There are almost 100 closed issues in the [2.0.3 milestone](https://github.com/twbs/bootstrap/issues?sort=created&direction=desc&state=closed&page=1&milestone=10) on GitHub, but below is a comprehensive list of the most important fixes with clear explanations of what's changed.

--- a/src/_posts/2012/2012-04-27-talking-about-bootstrap.md
+++ b/src/_posts/2012/2012-04-27-talking-about-bootstrap.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Talking about Bootstrap
+author: mdo
 ---
 
 There is a thread on the mailing list about [how to describe Bootstrap](https://groups.google.com/forum/#!topic/twitter-bootstrap/LL75NMBGdVA) and instead of isolating our response to just one email, I'll just blog about it. As it stands, some folks are unsure how to describe Bootstrap to those unfamiliar with it. So here it is, straight from the official horse's mouth.

--- a/src/_posts/2012/2012-04-30-new-release-strategy.md
+++ b/src/_posts/2012/2012-04-30-new-release-strategy.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: New release strategy
+author: mdo
 ---
 
 After three large point releases focusing on massive amounts of bugfixes and documentation changes, we're going to change up our release strategy to push out smaller, more frequent updates.

--- a/src/_posts/2012/2012-06-01-bootstrap-2-0-4-released.md
+++ b/src/_posts/2012/2012-06-01-bootstrap-2-0-4-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.0.4 released
+author: mdo
 ---
 
 Following up on the large 2.0.3 release a few weeks ago, we have a fresh update to address some documentation issues and basic CSS bugs. 2.0.4 includes around thirty closed issues and is our first version under our updated release approach (shorter, more concise releases).

--- a/src/_posts/2012/2012-08-11-now-powered-by-jekyll-and-github-pages.md
+++ b/src/_posts/2012/2012-08-11-now-powered-by-jekyll-and-github-pages.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Now powered by Jekyll and GitHub Pages
+author: mdo
 ---
 
 Sorry about the database connection issues some of you may have seen in the last 24 hours. We've moved off WordPress for our blog and are now using GitHub pages and Jekyll. Jekyll is an amazingly lightweight and simple site generator from Tom Preston-Werner, cofounder of GitHub. Here's why:

--- a/src/_posts/2012/2012-08-13-help-test-bootstrap-2-1.md
+++ b/src/_posts/2012/2012-08-13-help-test-bootstrap-2-1.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Help test Bootstrap 2.1
+author: mdo
 ---
 
 We're stoked to release Bootstrap 2.1 next week Monday at our [first birthday party](https://twitter-bootstrap-birthday.eventbrite.com/), but to make it a great release, we need your help testing it out.

--- a/src/_posts/2012/2012-08-20-bootstrap-2-1-0-released.md
+++ b/src/_posts/2012/2012-08-20-bootstrap-2-1-0-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.1.0 released
+author: mdo
 ---
 
 After a smaller 2.0.4 release, we've got another huge update that resolves tons of bugs, improves the flexibility and durability of our code, and introduces a few awesome new features. It's a big release wrapped in a brand new set of docs and we couldn't be more stoked to launch it.

--- a/src/_posts/2012/2012-08-22-new-rss-feed.md
+++ b/src/_posts/2012/2012-08-22-new-rss-feed.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: New RSS feed
+author: mdo
 ---
 
 Roughly two weeks ago we upgraded the blog to use Jekyll and GitHub Pages instead of WordPress. When we did that, we forgot about the RSS feed. A few awesome folks noted we were missing it and so we've added it back. Unfortunately it's not the same URL, but it's there nonetheless.

--- a/src/_posts/2012/2012-09-04-bootstrap-2-1-1-released.md
+++ b/src/_posts/2012/2012-09-04-bootstrap-2-1-1-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.1.1 released
+author: mdo
 ---
 
 [Two weeks later]({% post_url 2012/2012-08-20-bootstrap-2-1-0-released %}), we've closed another 500 issues against Bootstrap. That includes all the dupes—you nerds like reporting typos—and invalid issues that don't end up making it on the official release milestone. But, what's awesome is that we have 2.1.1 ready to rock with 73 bugfixes.

--- a/src/_posts/2012/2012-09-29-onward.md
+++ b/src/_posts/2012/2012-09-29-onward.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Onward
+author: mdo
 ---
 
 Working at Twitter the last two and a half years has been incredible. Both Jacob and I have worked with a lot of amazing people on some pretty amazing projects, but nothing has been more enjoyable or rewarding than working on Bootstrap. Despite us leaving Twitter to go our [separate ways](https://www.youtube.com/watch?v=LatorN4P9aA), we'll both be continuing our work on the project.
@@ -10,7 +11,3 @@ Bootstrap will remain a Twitter project on GitHub for the time being, but we've 
 In the coming weeks, we'll release another bugfix update (2.1.2) to address a few things, and then it's full steam ahead on improving some key areas of the framework (modals, carousels, customizer, etc). We'll share more info on those updates as plans take shape.
 
 Until then, we have nothing but love for Twitter and the web development community. Thank you all so much for everything.
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [@fat](https://twitter.com/fat)

--- a/src/_posts/2012/2012-10-29-bootstrap-2-2-0-released.md
+++ b/src/_posts/2012/2012-10-29-bootstrap-2-2-0-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.2.0 released
+author: mdo
 ---
 
 Aww yeah, our first release since leaving Twitter is here with Bootstrap 2.2.0! We originally planned to release this as 2.1.2, but given the timing and scope we're bumping the version. Included in this release are dozens of bug fixes, documentation enhancements, and a few new and improved features.
@@ -35,7 +36,3 @@ For the full list of issues included in this release, visit the [2.2.0 milestone
 As a quick side note, we're still working on moving Bootstrap to its own organization on GitHub. That will come with a couple other big changes, but more on that soon. We'll be jumping on the next release shortly for more bugfixes, but until then enjoy the fixes and new hotness!
 
 Lastly, thanks everyone again for submitting issues and contributing—you rock!
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [@fat](https://twitter.com/fat)

--- a/src/_posts/2012/2012-10-30-2-2-1-hotfix-released.md
+++ b/src/_posts/2012/2012-10-30-2-2-1-hotfix-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: 2.2.1 hotfix released
+author: mdo
 ---
 
 After the [2.2.0 release last night]({% post_url 2012/2012-10-29-bootstrap-2-2-0-released %}), a few bugs were reported, but only one major one: [malfunctioning carousels](https://twitter.com/getbootstrap/status/263327129905811459). To address that, [@fat](https://twitter.com/fat) just pushed out a 2.2.1 hotfix release that fixes the bug. Upgrading should be super simple given the scope of this release.

--- a/src/_posts/2012/2012-11-09-glyphicons-font.md
+++ b/src/_posts/2012/2012-11-09-glyphicons-font.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Update on the Glyphicons font
+author: mdo
 ---
 
 Earlier this week, I was excited to announce that our next release, `2.2.2-wip`, would include the new Glyphicons icon font. In hindsight I got a little carried away and forgot about something.
@@ -16,5 +17,3 @@ Backwards compatibility is always a pain in the ass, and to avoid huge headaches
 There's some good news though. For you nerds who live on the edge, I've been working on tons of BS3-esque changes in the `3.0.0-wip` branch on GitHub. If you really cannot wait for the Glyphicons font (and don't mind using unsupported code), do check it out. I plan on accelerating work on it in the coming weeks. (Please don't submit issues for it though, but rather email me or ping me on Twitter for questions.)
 
 Thanks for listening, and as always, <3<3<3.
-
-[@mdo](https://twitter.com/mdo)

--- a/src/_posts/2012/2012-12-02-help-test-2.2.2.md
+++ b/src/_posts/2012/2012-12-02-help-test-2.2.2.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Help test Bootstrap 2.2.2
+author: mdo
 ---
 
 In the next week or so, we plan on releasing `v2.2.2`. To date, there are over 50 CSS and documentation related issues already closed, and we want to get those out in your hands. We still have some significant JavaScript issues to work out, but those will be punted to 2.2.3 so we don't hold up development. Our hope is to have that release out by end of year at the latest.

--- a/src/_posts/2012/2012-12-08-bootstrap-2-2-2-released.md
+++ b/src/_posts/2012/2012-12-08-bootstrap-2-2-2-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.2.2 released
+author: mdo
 ---
 
 Today we're launching [Bootstrap 2.2.2]({{ site.main }}/), another larger bugfix release that focuses mostly on CSS and documentation fixes, with a few key JS issues mixed in as well. Here's the rundown on what's new in this release:

--- a/src/_posts/2012/2012-12-10-bootstrap-3-plans.md
+++ b/src/_posts/2012/2012-12-10-bootstrap-3-plans.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 3 plans
+author: mdo
 ---
 
 With 2.2.2 out the door, our attention has shifted almost entirely to the next major update to the project, Bootstrap 3. Things are coming together and we want to give you an update on what's next and give you a chance to share your thoughts.
@@ -53,7 +54,3 @@ Growing the team with official contributors, other than the two of us, is also a
 Bootstrap is still just getting started. There is so much more awesome stuff to do and we want to work with you awesome folks to do it all as best we can. We hope you're as excited as we are.
 
 Please reach out to us on Twitter or GitHub with any questions or feedback.
-
-<3,
-
-@mdo and @fat

--- a/src/_posts/2013/2013-02-07-bootstrap-2-3-released.md
+++ b/src/_posts/2013/2013-02-07-bootstrap-2-3-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.3 released
+author: mdo
 ---
 
 It has been far too long, friends. Nearly three months has gone by since we pushed out a new version of Bootstrap, but fret not, for that void comes to a most excellent halt tonight. After numerous delays, including a bout with the flu, we're happy to announce the release of [Bootstrap 2.3]({{ site.main }}/).
@@ -57,7 +58,3 @@ As we've previously mentioned, v2.3 is our last planned release before moving on
 - And a whole mess of other changes.
 
 And that's just some of the highlights. Again, [peep the pull request](https://github.com/twbs/bootstrap/pull/6342) for the most up to date changes as we continue to chip away at this bad boy. Feel free to comment on that, or hit us up on Twitter, for feedback of any kind.
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [@fat](https://twitter.com/fat)

--- a/src/_posts/2013/2013-03-01-bootstrap-2-3-1-released.md
+++ b/src/_posts/2013/2013-03-01-bootstrap-2-3-1-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.3.1 released
+author: mdo
 ---
 
 While Bootstrap 2.3 was the last planned release ahead of 3.0, we've just pushed out a small patch to address a few lingering JavaScript bugs. [Bootstrap 3](https://github.com/twbs/bootstrap/pull/6342) is still under development and is trucking along quite nicely. We'll have more to share there soon.
@@ -18,7 +19,3 @@ Check out the [2.3.1 pull request](https://github.com/twbs/bootstrap/pull/7111) 
 <a class="btn-link" href="https://github.com/twbs/bootstrap/archive/v2.3.1.zip">Download Bootstrap 2.3.1</a> <span class="muted">(latest master ZIP)</span>
 
 **Side note:** Aside from the fixes in this release, future bugs will only be addressed in 3.0, or punted entirely, as appropriate. This release just fixes a few things left broken that we didn't feel comfortable ignoring for the next several weeks.
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [@fat](https://twitter.com/fat)

--- a/src/_posts/2013/2013-03-03-bootstrap-expo.md
+++ b/src/_posts/2013/2013-03-03-bootstrap-expo.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Welcome to the Bootstrap Expo
+author: mdo
 ---
 
 [![Bootstrap Expo](/assets/img/2013/03/bootstrap-expo.jpg)]({{ site.expo }})
@@ -11,6 +12,4 @@ The Bootstrap Expo is all hosted on GitHub, meaning recommending new sites is as
 
 As a side note, the Expo is the second project appearing under the [twbs organization](https://github.com/twbs) (this blog is already there in private mode). We'll be moving Bootstrap and the Customizer over with v3 soon.
 
-Until then, enjoy and <3,
-
-[@mdo](https://twitter.com/mdo)
+Until then, enjoy and <3.

--- a/src/_posts/2013/2013-05-17-bootstrap-2-3-2-released.md
+++ b/src/_posts/2013/2013-05-17-bootstrap-2-3-2-released.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 2.3.2 released
+author: mdo
 ---
 
 This morning we pushed out a 2.3.2 patch release to address a single bug (<a href="https://github.com/twbs/bootstrap/issues/7118" rel="noopener" target="_blank">see #7118</a>) related to dropdowns and command/control clicking links in Firefox.
@@ -8,7 +9,3 @@ This morning we pushed out a 2.3.2 patch release to address a single bug (<a hre
 Work on Bootstrap 3 continues and we're almost ready to do an official release candidate. We've addressed nearly all our chosen changes and are now at a point where we're smoothing things out as much as possible. We'll share more information on the RC and v3 in the coming weeks.
 
 <a class="btn-link" href="https://github.com/twbs/bootstrap/archive/v2.3.2.zip">Download Bootstrap 2.3.2</a> <span class="muted">(latest master ZIP)</span>
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [@fat](https://twitter.com/fat)

--- a/src/_posts/2013/2013-07-18-ante-up.md
+++ b/src/_posts/2013/2013-07-18-ante-up.md
@@ -2,6 +2,7 @@
 layout: post
 title: Ante up.
 video: 21OH0wlkfbc
+author: mdo
 ---
 
 August 19.

--- a/src/_posts/2013/2013-07-27-bootstrap-3-rc1.md
+++ b/src/_posts/2013/2013-07-27-bootstrap-3-rc1.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3 RC1
 video: uB1D9wWxd2w
+author: mdo
 ---
 
 Today we're releasing the first of at least two release candidates for Bootstrap 3, and along with it a slew of updates to the project and community. Buckle up.
@@ -25,8 +26,3 @@ With over ~1,600 commits, ~72,000 additions/deletions, and ~300 files changed, *
 ## Onward to RC2
 
 Bootstrap 3 RC1 is just the start, and we need your help to get to RC2. Download it and give it a go, and most importantly, tell us what you find. If something new is all funky or you found a bug, let us know by [opening a new issue](https://github.com/twbs/bootstrap/issues/new).
-
-
-<3,
-
-@mdo and @fat

--- a/src/_posts/2013/2013-08-13-bootstrap-3-rc2.md
+++ b/src/_posts/2013/2013-08-13-bootstrap-3-rc2.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3 RC2
 video: wiyYozeOoKs
+author: mdo
 ---
 
 We've just cut a new release for Bootstrap 3, RC2. It's a big release as lots has changed, but that should all be for the better. Thanks everyone who's given feedback and submitted pull requests thus far—we're getting super close!

--- a/src/_posts/2013/2013-08-19-bootstrap-3-released.md
+++ b/src/_posts/2013/2013-08-19-bootstrap-3-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3 released
 video: 0hiUuL5uTKc
+author: mdo
 ---
 
 Today, on the two year anniversary of releasing Bootstrap to the world, we're shipping Bootstrap 3.0. It's been a crazy long ride to say the least and we're stoked to finally have this out in the wild. Thanks to everyone who's tested our RCs (er, betas), reported bugs, and contributed code. We couldn't have done it without you beautiful nerds.
@@ -87,10 +88,3 @@ No dates have been set for any patch or minor release yet. As soon as we figure 
 Woo, all set? Then head to the docs and download yourself some Bootstrap 3!
 
 <a class="btn-link" href="https://github.com/twbs/bootstrap/archive/v3.0.0.zip">Download Bootstrap 3</a> or hit the [GitHub repository](https://github.com/twbs/bootstrap)
-
-
------
-
-<3,
-
-[@mdo](https://twitter.com/mdo), [@fat](https://twitter.com/fat), and [team](https://github.com/twbs/bootstrap/contributors)

--- a/src/_posts/2013/2013-10-29-bootstrap-3-0-1-released.md
+++ b/src/_posts/2013/2013-10-29-bootstrap-3-0-1-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.0.1 released
 video: fdKsgBNEHUU
+author: mdo
 ---
 
 Today we're shipping v3.0.1, a huge patch release with over 750 commits since v3 was released two months ago. We've outlined most of the changes below, including documentation updates, bug fixes, and even a few deprecations (our first in the history of the project).
@@ -190,9 +191,3 @@ It'll be a slow process, much like last time, but we need the help on several fr
 ## Up next
 
 We're already tracking issues for a v3.0.2 release and its changes will be along the same lines as today's release—bugs and docs. v3.1.0 will likely ship after that sometime with a few new features. As always, no dates have been set yet for any future releases.
-
------
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2013/2013-11-06-bootstrap-3-0-2-released.md
+++ b/src/_posts/2013/2013-11-06-bootstrap-3-0-2-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.0.2 released
 video: -eSN8Cwit_s
+author: mdo
 ---
 
 Today we're shipping a quick v3.0.2 patch to fix incorrect version numbers in our JavaScript files, restore missing grid classes, and make a few improvements to our documentation.
@@ -36,9 +37,3 @@ As always, get the details from the [v3.0.2 milestone](https://github.com/twbs/b
 ## Up next
 
 This release was unplanned, and as such it bumps a lot of planned fixes to a v3.0.3 release. We've already updated the relevant issues to be under the new v3.0.3 milestone. Look for that release, and perhaps another patch, before v3.1.0 ships in the coming months.
-
------
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2013/2013-12-05-bootstrap-3-0-3-released.md
+++ b/src/_posts/2013/2013-12-05-bootstrap-3-0-3-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.0.3 released
 video: xy4FXhkm6Nw
+author: mdo
 ---
 
 Today we're shipping another patch release, v3.0.3, to fix a few dozen bugs and improve our documentation.
@@ -99,9 +100,3 @@ As always, get the details from the [v3.0.3 milestone](https://github.com/twbs/b
 ## Up next
 
 Next up is v3.1.0, the first new feature release for Bootstrap 3. Stay tuned for more information on what'll be in that release as we continue to plan out subsequent releases.
-
------
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2014/2014-01-30-bootstrap-3-1-0-released.md
+++ b/src/_posts/2014/2014-01-30-bootstrap-3-1-0-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.1.0 released
 video: phOW-CZJWT0
+author: mdo
 ---
 
 Today we're stoked to ship Bootstrap v3.1. We've got a handful of new features, plenty of bug fixes and improvements, and updated build tools.

--- a/src/_posts/2014/2014-02-13-bootstrap-3-1-1-released.md
+++ b/src/_posts/2014/2014-02-13-bootstrap-3-1-1-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.1.1 released
 video: WMPM1q_Uyxc
+author: mdo
 ---
 
 Today we're releasing Bootstrap v3.1.1. As our first patch release for the v3.1.x release series, we've focused on CSS bug fixes, documentation improvements, and further refinements to our build tools. See the included changelog for more details.

--- a/src/_posts/2014/2014-02-25-ratchet-2.md
+++ b/src/_posts/2014/2014-02-25-ratchet-2.md
@@ -2,6 +2,7 @@
 layout: post
 title: Introducing Ratchet 2
 video: vimZj8HW0Kg
+author: mdo
 ---
 
 Today we're stoked to introduce the brand spanking new [Ratchet 2.0](http://goratchet.com/). The mobile-only framework for building mobile apps with HTML, CSS, and JavaScript has been overhauled with new features, documentation, and a brand new home.
@@ -57,7 +58,3 @@ Be sure to check out the [GitHub milestone](https://github.com/twbs/ratchet/issu
 Just like Bootstrap releases, up next for Ratchet will be documentation improvements and bug fixes as feedback rolls in. Without committing to a date, we also want to add support for iPad and Android tablets.
 
 As always, if you find a bug or want to suggest a feature, just [open an issue](https://github.com/twbs/ratchet/issues/new) or a pull request on [GitHub](https://github.com/twbs/ratchet/).
-
-<3,
-
-[@mdo](https://twitter.com/mdo) and [@connors](https://twitter.com/connors)

--- a/src/_posts/2014/2014-03-05-ratchet-2-0-1-released.md
+++ b/src/_posts/2014/2014-03-05-ratchet-2-0-1-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Ratchet 2.0.1 released
 video: otCpCn0l4Wo
+author: connors
 ---
 
 Today we're pumped to release Ratchet 2.0.1. This release focuses on CSS bug fixes and further improvements to our docs and build tools. Be sure to check out the detailed [changelog](https://github.com/twbs/ratchet/releases/tag/v2.0.1) on the release page.
@@ -15,8 +16,3 @@ For a complete list of changes, see the [v2.0.1 milestone](https://github.com/tw
 ## In other news
 
 Since releasing Ratchet 2.0.0 we've reached over **7,000 stars** and over **650 forks on GitHub**! Thanks to all our contributors and the rest of the community for helping make this thing awesome.
-
-
-<3,
-
-[@connors](https://twitter.com/connors) & [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2014/2014-04-02-ratchet-2-0-2-released.md
+++ b/src/_posts/2014/2014-04-02-ratchet-2-0-2-released.md
@@ -16,7 +16,3 @@ For a complete list of changes, see the [v2.0.2 milestone](https://github.com/tw
 ## What's next
 
 We're going to be working on the v2.1.0 release next. This will mark the first feature release for Ratchet 2. We're really looking forward to developing more components that help you build awesome apps.
-
-<3,
-
-[@connors](https://twitter.com/connors) & [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2014/2014-06-09-bootstrap-npm.md
+++ b/src/_posts/2014/2014-06-09-bootstrap-npm.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap now available via npm
 video: z33tH-JdPDg
+author: mdo
 ---
 
 It's taken us awhile, but we've finally [published Bootstrap on npm](https://www.npmjs.com/package/bootstrap). We've taken over the existing `bootstrap` package and just published the latest release, v3.1.1. The package is managed by the [twbs user](https://www.npmjs.com/org/twbs), just like on GitHub. In the future, when we release new versions of Bootstrap, we'll update npm as well.

--- a/src/_posts/2014/2014-06-25-lmvtfy.md
+++ b/src/_posts/2014/2014-06-25-lmvtfy.md
@@ -12,7 +12,3 @@ To that end, we are excited to announce the availability of **[Let Me Validate T
 The bot is generic and can be used for any GitHub project, not just Bootstrap. If you have a front-end Web project on GitHub that gets lots of issue reports, we invite you to try out LMVTFY.
 
 For more details, setup instructions, or to give feedback, [check out the LMVTFY project on GitHub](https://github.com/cvrebert/lmvtfy).
-
-<3,
-
-[@cvrebert](https://twitter.com/cvrebert) and [team](https://github.com/twbs)

--- a/src/_posts/2014/2014-06-26-bootstrap-3-2-0-released.md
+++ b/src/_posts/2014/2014-06-26-bootstrap-3-2-0-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.2.0 released
 video: LaTGrV58wec
+author: mdo
 ---
 
 Today we're shipping Bootstrap v3.2.0, a monster of a release that's been in the works for four months. There's lots of new hotness, hundreds of bug fixes, plenty of documentation improvements, and some build tool improvements. All told, there have been over 1,000 commits since our last release.
@@ -68,7 +69,3 @@ For a complete breakdown, [read the release changelog](https://github.com/twbs/b
 ## What's next
 
 Well, we'll probably have a patch release (v3.2.1), and then I imagine it's onward to v4. We have a v3.3.0 milestone on GitHub, but it's still unclear if we'll ship that before jumping to v4. We've been building a list of things we'd like to see in the new version, but we don't have anything ready for the public yet. We'll share more details as we have them though. Until then, enjoy!
-
-<3,
-
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2014/2014-09-23-bootlint.md
+++ b/src/_posts/2014/2014-09-23-bootlint.md
@@ -12,7 +12,3 @@ Pointing out the same mistakes repeatedly gets tiring, so once again, we decided
 We encourage you to add Bootlint to your web development toolchain so that none of the common mistakes slow down your project's development. In the future, we hope to also make a GitHub issues bot based on Bootlint to help folks out on the Bootstrap issue tracker.
 
 For more details, installation & usage instructions, or to contribute or give feedback, [check out the Bootlint project on GitHub!](https://github.com/twbs/bootlint)
-
-<3,
-
-[@cvrebert](https://twitter.com/cvrebert) and [team](https://github.com/twbs)

--- a/src/_posts/2014/2014-10-13-rorschach.md
+++ b/src/_posts/2014/2014-10-13-rorschach.md
@@ -14,7 +14,3 @@ Rorschach automatically gives instant feedback on Bootstrap pull requests that s
 Previously, these mistakes were checked for manually, which meant there was often a delay before the mistake was noticed and that pull request reviewers had to manually explain the mistake to the contributor each time. With Rorschach, everyone should have a smoother experience working on Bootstrap.
 
 Happy pull requesting!
-
-<3,
-
-[@cvrebert](https://github.com/cvrebert) and [team](https://github.com/twbs)

--- a/src/_posts/2014/2014-10-29-bootstrap-3-3-0-released.md
+++ b/src/_posts/2014/2014-10-29-bootstrap-3-3-0-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.3.0 released
 video: Zr9R7hN1YSs
+author: mdo
 ---
 
 Bootstrap 3.3.0 is here! This release has been all about bug fixes, accessibility improvements, and documentation updates. We've had over 700 commits from 28 contributors since our last release. Woohoo!
@@ -55,7 +56,3 @@ Perhaps the best part of releasing v3.3.0 today is that we can start to tell you
 - And hundreds more changes across the board.
 
 We'd love to tell you more, but the dust still has to settle before we open our first pull request with a live alpha release. In addition to launching in v4 in the coming months, we'll be maintaining v3 with small bugfixes for the first few months after the new version ships.
-
-<3,
-
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2014/2014-11-12-bootstrap-3-3-1-released.md
+++ b/src/_posts/2014/2014-11-12-bootstrap-3-3-1-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.3.1 released
 video: ydd9Dn3bJlI
+author: mdo
 ---
 
 Say hello to Bootstrap 3.3.1. As one of our fastest follow up releases, the changelog is focused around a small set of bug fixes for our CSS and JS, loads of accessibility improvements, and several documentation improvements.
@@ -30,7 +31,3 @@ After reviewing the changelog, update your CDN links to point to the v3.3.1 file
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 {% endhighlight %}
-
-<3,
-
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2015/2015-01-19-bootstrap-3-3-2-released.md
+++ b/src/_posts/2015/2015-01-19-bootstrap-3-3-2-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.3.2 released
 video: DNPjeIamsck
+author: mdo
 ---
 
 Bootstrap 3.3.2 is here! This release has been all about bug fixes, accessibility improvements, and documentation updates. We've had over 300 commits from 19 contributors since our last release. Woohoo!
@@ -47,7 +48,3 @@ After reviewing the changelog, update your CDN links to point to the v3.3.2 file
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
 {% endhighlight %}
-
-<3,
-
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2015/2015-03-16-bootstrap-3-3-4-released.md
+++ b/src/_posts/2015/2015-03-16-bootstrap-3-3-4-released.md
@@ -45,7 +45,3 @@ After reviewing the changelog, update your CDN links to point to the v3.3.4 file
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 {% endhighlight %}
-
-<3,
-
-[@cvrebert](https://github.com/cvrebert) & [team](https://github.com/orgs/twbs/people)

--- a/src/_posts/2015/2015-06-15-bootstrap-3-3-5-released.md
+++ b/src/_posts/2015/2015-06-15-bootstrap-3-3-5-released.md
@@ -68,7 +68,3 @@ After reviewing the changelog, update your CDN links to point to the v3.3.5 file
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
 {% endhighlight %}
-
-<3,
-
-[@cvrebert](https://github.com/cvrebert) & [team]({{ site.main }}/about/#team)

--- a/src/_posts/2015/2015-08-04-no-carrier.md
+++ b/src/_posts/2015/2015-08-04-no-carrier.md
@@ -10,7 +10,3 @@ Say hello to our newest bot, **No Carrier**. Inspired by the classic modem disco
 To date, we've handled abandoned issues just like any other issues—with ad-hoc reviews. We felt that could be improved, so we made a bot to automate the process. No Carrier appears on our issue tracker as [@twbs-closer](https://github.com/twbs-closer?tab=activity) and will monitor issues we tag with [`awaiting-reply`](https://github.com/twbs/bootstrap/labels/awaiting%20reply). Should no one reply within two weeks, **@twbs-closer** will post a final comment explaining the situation and our policy, and then automatically close the issue. If someone later replies after the cutoff, a member of our team will happily reopen the issue manually and continue pursuing it.
 
 No Carrier is available for any GitHub project, not just Bootstrap. If you have a project on GitHub that might benefit from this automation, we invite you to try out No Carrier. For more details, usage instructions, and feedback, [check out the No Carrier project on GitHub](https://github.com/twbs/no-carrier). You can download the assembly JAR from the "Downloads" section of [the v1.0.0 release page](https://github.com/twbs/no-carrier/releases/tag/v1.0.0).
-
-<3,
-
-[@cvrebert](https://github.com/cvrebert) & [team](https://github.com/twbs)

--- a/src/_posts/2015/2015-08-19-bootstrap-4-alpha.md
+++ b/src/_posts/2015/2015-08-19-bootstrap-4-alpha.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 alpha
 video: 4PdU6migsqQ
+author: mdo
 ---
 
 Today is a special day for Bootstrap. Not only is it our fourth birthday, but after a year of development, we're finally shipping the first alpha release of Bootstrap 4. Hell yeah!
@@ -62,7 +63,3 @@ To start, we're launching with three themes built on Bootstrap 3: a [dashboard](
 All themes include a [multiple-use license]({{ site.themes }}licenses/) for the purchaser and free updates for bug fixes and documentation updates for the life of the themes.
 
 [Head to the Bootstrap themes site]({{ site.themes }}) to check them out.
-
-<3,
-
-[@mdo](https://twitter.com/mdo), [@fat](https://twitter.com/fat), & [team](https://github.com/twbs)

--- a/src/_posts/2015/2015-11-24-bootstrap-3-3-6-released.md
+++ b/src/_posts/2015/2015-11-24-bootstrap-3-3-6-released.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.3.6 released
 video: l-O5IHVhWj0
+author: mdo
 ---
 
 Bootstrap 3.3.6 is here! It's a long overdue release that addresses dozens of CSS bug fixes and documentation updates. We've had over 180 commits and 100 closed issues and pull requests from nearly 30 contributors since our last release. Woohoo!
@@ -38,7 +39,3 @@ After reviewing the changelog, update your CDN links to point to the v3.3.6 file
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 {% endhighlight %}
-
-<3,
-
-[@mdo](https://twitter.com/mdo) & [team]({{ site.main }}/about/#team)

--- a/src/_posts/2015/2015-12-08-bootstrap-4-alpha-2.md
+++ b/src/_posts/2015/2015-12-08-bootstrap-4-alpha-2.md
@@ -2,6 +2,7 @@
 layout: post
 title: New Bootstrap 4 alpha
 video: J_kokTee01k
+author: mdo
 ---
 
 Bootstrap 4 alpha 2 is now available. Since [our last release]({% post_url 2015/2015-08-19-bootstrap-4-alpha %}), nearly 100 people have pushed over 900 commits to v4 and we've closed over 400 issues and pull requests. Those numbers are outrageously awesome to see, and we've still got a ton of work ahead of us this year for v4.
@@ -28,7 +29,3 @@ We highly encourage folks to skim through [the second alpha's milestone on GitHu
 **Ready to dive in? Then [head to the v4 alpha docs!](https://v4-alpha.getbootstrap.com/)**
 
 Be sure to [join our official Slack room!](https://bootstrap-slack.herokuapp.com) and dive into [our issue tracker](https://github.com/twbs/bootstrap/issues/) with bug reports, questions, and general feedback whenever possible.
-
-<3,
-
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2016/2016-07-25-bootstrap-3-3-7-released.md
+++ b/src/_posts/2016/2016-07-25-bootstrap-3-3-7-released.md
@@ -38,7 +38,3 @@ After reviewing the changelog, update your CDN links to point to the v3.3.7 file
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 {% endhighlight %}
-
-<3,
-
-[@cvrebert](https://twitter.com/cvrebert) & [team]({{ site.main }}/about/#team)

--- a/src/_posts/2016/2016-07-27-bootstrap-4-alpha-3.md
+++ b/src/_posts/2016/2016-07-27-bootstrap-4-alpha-3.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 Alpha 3
 video: xFrGuyw1V8s
+author: mdo
 ---
 
 Alpha 3 has landed! We have an overhauled grid, updated form controls, a new font stack, tons of bug fixes, and more. It's been several months since our last update, but the size of this update should help get us back on track.
@@ -91,6 +92,3 @@ Be sure to [join our official Slack room!](https://bootstrap-slack.herokuapp.com
 ## What's next?
 
 More exploration, more bugfixes, more docs updates, and, best of all, more alphas. The daily grind keeps us super busy these days, but we'll do our best to keep the momentum going. Stay tuned!
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2016/2016-09-05-bootstrap-4-alpha-4.md
+++ b/src/_posts/2016/2016-09-05-bootstrap-4-alpha-4.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 Alpha 4
 video: p0OX_8YvFxA
+author: mdo
 ---
 
 [Alpha 4 is here](https://v4-alpha.getbootstrap.com/) to address those pesky build and package errors, a few CSS bugs, and some documentation inconsistencies we introduced in our last release.
@@ -27,6 +28,3 @@ For more details on this release's changes, take a look at the [Alpha 4 ship lis
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.4/js/bootstrap.min.js" integrity="sha384-VjEeINv9OSwtWFLAtmc4JCtEJXXBub00gtSnszmspDLCtC0I4z4nqz7rEFbIZLLU" crossorigin="anonymous"></script>
 {% endhighlight %}
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2016/2016-10-19-bootstrap-4-alpha-5.md
+++ b/src/_posts/2016/2016-10-19-bootstrap-4-alpha-5.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 Alpha 5
 video: MxGEVIvSFeY
+author: mdo
 ---
 
 [Alpha 5 has arrived](https://v4-alpha.getbootstrap.com/) just over a month after Alpha 4 with some major feature improvements and a boat load of bug fixes. We still have a lot of work to do, but we're closing the gap and getting more stable with each release. Keep reading for the highlights and plans for Alpha 6.
@@ -73,6 +74,3 @@ For more details on this release's changes, take a look at the [Alpha 5 ship lis
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
 {% endhighlight %}
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2017/2017-01-06-bootstrap-4-alpha-6.md
+++ b/src/_posts/2017/2017-01-06-bootstrap-4-alpha-6.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 Alpha 6
 video: V44HiAX91Hs
+author: mdo
 ---
 
 [Alpha 6 has landed](https://v4-alpha.getbootstrap.com/), and it's one of our biggest ships to date. We've rewritten our grid system and all major components in flexbox, forging ahead with it as our default layout option as we drop IE9 support. With 700 commits since our last release, we have some catching up to do.
@@ -81,7 +82,5 @@ For more details on this release's changes, take a look at the [Alpha 6 ship lis
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 {% endhighlight %}
 
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)
 
 <script src="https://static.jsbin.com/js/embed.min.js"></script>

--- a/src/_posts/2017/2017-08-10-bootstrap-4-beta.md
+++ b/src/_posts/2017/2017-08-10-bootstrap-4-beta.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 Beta
 video: aQUlA8Hcv4s
+author: mdo
 ---
 
 [Two years in the making]({% post_url 2015/2015-08-19-bootstrap-4-alpha %}), we finally have our first beta release of Bootstrap 4. In that time, we've broken all the things at least twenty-seven times over with nearly 5,000 commits, 650+ files changed, 67,000 lines added, and 82,000 lines deleted. We also shipped six major alpha releases, a trio of official Themes, and even a job board for good measure. Put simply? [It's about time.](https://www.youtube.com/watch?v=_J6-3l3hCm0)
@@ -37,6 +38,3 @@ In addition to a new color palette and new systems fonts, we have a brand new la
 ---
 
 For more details on this release's changes, take a look at the [Beta 1 ship list issue](https://github.com/twbs/bootstrap/issues/21568), as well as the [closed Beta 1 milestone](https://github.com/twbs/bootstrap/milestone/41?closed=1). Be sure to [join our official Slack room!](https://bootstrap-slack.herokuapp.com) and dive into [our issue tracker](https://github.com/twbs/bootstrap/issues/) with bug reports, questions, and general feedback whenever possible.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2017/2017-10-19-bootstrap-4-beta-2.md
+++ b/src/_posts/2017/2017-10-19-bootstrap-4-beta-2.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 Beta 2
 video: MqnZ1RpmxBg
+author: mdo
 ---
 
 Just over two months ago we shipped our first beta for Bootstrap 4, and now we're ready to share our second with you. We've improved customization, documentation, build tooling, and naming inconsistencies all while fixing hella bugs.
@@ -76,6 +77,3 @@ After Beta 3, we're hoping to quickly move into a final v4 release. Ideally, it'
 ---
 
 For more details on this release's changes, take a look at the [Beta 2 ship list issue](https://github.com/twbs/bootstrap/issues/23278), as well as the [Beta 2 project](https://github.com/twbs/bootstrap/projects/4). Be sure to [join our official Slack room!](https://bootstrap-slack.herokuapp.com) and dive into [our issue tracker](https://github.com/twbs/bootstrap/issues/) with bug reports, questions, and general feedback whenever possible.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2017/2017-12-28-bootstrap-4-beta-3.md
+++ b/src/_posts/2017/2017-12-28-bootstrap-4-beta-3.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4 Beta 3
 video: 9jK-NcRmVcw
+author: mdo
 ---
 
 Welcome to the final beta of v4! It's been over two months since we shipped our second beta and we've been busy making the last breaking changes before moving to our next stable release, v4.0.0! We have a few more breaking changes than we were planning, but fret not, we've detailed them all.
@@ -50,6 +51,3 @@ With our next release, the `master` branch will once again become our default br
 
 
 See you again real soon!
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2018/2018-01-18-bootstrap-4.md
+++ b/src/_posts/2018/2018-01-18-bootstrap-4.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4
 video: VcjzHMhBtf0
+author: mdo
 ---
 
 It's literally taken us years to do it, but Bootstrap 4 has finally arrived! Words cannot begin to describe the elation the entire team and I have for this release, but I'll do my best. Thank you to everyone, especially to the team, and to everyone who's contributed code in a pull request or opened an issue. **Thank you.**
@@ -93,6 +94,3 @@ Stay tuned for more information as we get ready to launch.
 Finally, one last thank you to everyone who's contributed to Bootstrap 4. It's been a crazy journey and I'm personally relieved, thrilled, and anxious to call it stable. There have been roughly 6,000 commits to v4 since we first starting working on it back in 2015. We've gone every which direction and rewrote far too many things far too many times, but I'm so very happy and fortunate with where we landed.
 
 Cheers once again to everyone who's contributed to and built with Bootstrap. It's an honor to be building these kind of tools alongside and for all of you.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2018/2018-02-21-new-bootstrap-themes.md
+++ b/src/_posts/2018/2018-02-21-new-bootstrap-themes.md
@@ -2,6 +2,7 @@
 layout: post
 title: New Bootstrap themes
 video: atxUuldUcfI
+author: mdo
 ---
 
 Just over a month ago, we shipped the long awaited Bootstrap 4 stable release. With a brand new codebase designed to better support customization with all new components and documentation, it was the perfect time to debut some brand new themes built. Today, we'd like to introduce you to our brand new [Bootstrap Themes marketplace]({{ site.themes }}).

--- a/src/_posts/2018/2018-04-09-bootstrap-4-1.md
+++ b/src/_posts/2018/2018-04-09-bootstrap-4-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.1
 video: 3wxyN3z9PL4
+author: mdo
 ---
 
 Two months ago we shipped the [first major release of Bootstrap 4]({% post_url 2018/2018-01-18-bootstrap-4 %}) and we're thrilled y'all love the latest release and [our brand new themes]({% post_url 2018/2018-02-21-new-bootstrap-themes %}) so much. Today we're shipping our first minor release, v4.1! This release comes later than expected and some of the fixes we intended, but there's still a boatload of fixes, docs updates, build tool changes, and even a few small new features.
@@ -34,6 +35,3 @@ Be sure to look at the [ship list](https://github.com/twbs/bootstrap/issues/2537
 ## Next release
 
 Next up, we're looking at a [v4.1.1 release](https://github.com/twbs/bootstrap/projects/13). There are some bug fixes for input groups, form fields, and more that I know we need to tackle sooner than later. These were supposed to be in v4.1, but we couldn't make it happen in time.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2018/2018-04-30-bootstrap-4-1-1.md
+++ b/src/_posts/2018/2018-04-30-bootstrap-4-1-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.1.1
 video: 9jNt7ZGCW-o
+author: mdo
 ---
 
 We're a few weeks out from v4.1 and we have our first patch release of Bootstrap 4! It's a straightforward set of bug fixes and build tool quality of life updates.
@@ -17,6 +18,3 @@ Here's a quick rundown of some of the changes:
 - Fixed docs issue with incorrect name for our monospace font utility
 
 Checkout the full [v4.1.1 ship list](https://github.com/twbs/bootstrap/issues/25971) and [GitHub project](https://github.com/twbs/bootstrap/projects/13) for the full details. Up next will be [v4.1.2](https://github.com/twbs/bootstrap/projects/14), another patch release to address the next set of CSS and JS bugs you've help share with us since v4 launched.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2018/2018-07-12-bootstrap-4-1-2.md
+++ b/src/_posts/2018/2018-07-12-bootstrap-4-1-2.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.1.2
 video: qHDy_b33cCQ
+author: mdo
 ---
 
 We've been busy these last couple months since launching v4.1.1, but we're back with another bug fix and some sweeping changes to how we build and publish our docs after the issues stemming from our v4.1.x launches.
@@ -21,6 +22,3 @@ Beyond the file structure changes, here are the highlights for v4.1.2:
 Checkout the full [v4.1.2 ship list](https://github.com/twbs/bootstrap/issues/26423) and [GitHub project](https://github.com/twbs/bootstrap/projects/14) for the full details. Up next will either be [v4.1.3](https://github.com/twbs/bootstrap/projects/15) or [v4.2](https://github.com/twbs/bootstrap/projects/6) depending on how smoothly this release goes and how well we can keep up with reviewing and merging pull requests.
 
 Head to the v4.1.x docs to see the latest in action. The full release has been published to npm and will soon appear on the Bootstrap CDN and Rubygems.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2018/2018-07-24-bootstrap-4-1-3.md
+++ b/src/_posts/2018/2018-07-24-bootstrap-4-1-3.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.1.3
 video: LqB9lhHqmsE
+author: mdo
 ---
 
 Hot on the heels of v4.1.2, we're shipping another patch release to address an issue with our browserslist config, fix some CSS bugs, make JavaScript plugins UMD ready, and improve form control rendering. Up next will be v4.2, our second minor release where we add some new features.
@@ -18,6 +19,3 @@ But first, here are the highlights for v4.1.3. Pay attention to the change to `.
 Checkout the full [v4.1.3 ship list](https://github.com/twbs/bootstrap/issues/26867) and [GitHub project](https://github.com/twbs/bootstrap/projects/15) for the full details. Up next is [v4.2](https://github.com/twbs/bootstrap/projects/6), so stay tuned for some awesome new features like toasts, dismissible badges, negative margins (responsive grid gutters!), spinners, and more!
 
 [Head to the v4.1.x docs]({{ site.main }}/docs/4.1/) to see the latest in action. The full release has been published to npm and will soon appear on the Bootstrap CDN and Rubygems.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2018/2018-12-13-bootstrap-3-4-0.md
+++ b/src/_posts/2018/2018-12-13-bootstrap-3-4-0.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 3.4.0
 video: 8WEtxJ4-sh4
+author: mdo
 ---
 
 That's not a typo—today we're shipping Bootstrap 3.4.0, a long overdue update to address some quality of life issues, XSS fixes, and build tooling updates to make it easier for us, and you, to develop.
@@ -46,6 +47,3 @@ Also new with our v3.4 is the creation of an [Open Collective page](https://open
 We've been working on a [huge v4.2 update](https://github.com/twbs/bootstrap/projects/6?fullscreen=true) for several months now. Our attention has largely been on advancing the project and simplifying it's dependencies, namely by removing our jQuery dependency. That work has sparked a keen interest in a moderately scoped v5 release, so we've been taking our sweet time with v4.2 to sneak in as many new features as we can.
 
 After we ship v4.2, we'll plan for point releases to address any bugs and improvements as y'all start to use the new version. From there, we'll start to share more plans on v5 to remove jQuery, drop support for older browsers, and clear up some cruft. This won't be a sweeping rewrite, but rather an iterative improvement on v4. Stay tuned!
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2018/2018-12-21-bootstrap-4-2-1.md
+++ b/src/_posts/2018/2018-12-21-bootstrap-4-2-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.2.1
 video: 4N1iwQxiHrs
+author: mdo
 ---
 
 Look out world, we're shipping Bootstrap v4.2.1 with a slew of new features, bug fixes, and docs updates. On the new features side, we have spinners, toasts, switches, and (finally!) touch support in the carousel. That's just the tip of the iceberg though.
@@ -47,6 +48,3 @@ Bootstrap 5 will not feature drastic changes to the codebase. While I tweeted ab
 Stay tuned for a preview of the plans for v5 in the new year. We'll share via an issue, ask for feedback, and then settle in to development mode.
 
 Happy holidays, and happy new year to everyone! Thanks for continuing to make Bootstrap an amazing project and community.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2019/2019-02-11-bootstrap-4-3-0.md
+++ b/src/_posts/2019/2019-02-11-bootstrap-4-3-0.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.3.0
 video: htgr3pvBr-I
+author: mdo
 ---
 
 Bootstrap v4.3 has landed with over 120 combined closed issues and merged pull requests. This release brings improvements to our utilities, some prep work for moving on to v5's development, and the standard bug fixes and documentation updates.
@@ -59,6 +60,3 @@ Right after shipping v4.3, we'll be tackling a few key changes on our road to ac
 - **We're dropping jQuery for regular JavaScript.** The cat is out of the bag—we're dropping our largest client-side dependency for regular JavaScript. Similar to the Hugo move, we've been working on this for a long time and have a [pull request in progress](https://github.com/twbs/bootstrap/pull/23586) and near completion.
 
 We'll have even more to share soon around v5's plans after we tackle these bigger items. In the meantime, keep the feedback coming on GitHub and Twitter!
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2019/2019-02-13-bootstrap-4-3-1-and-3-4-1.md
+++ b/src/_posts/2019/2019-02-13-bootstrap-4-3-1-and-3-4-1.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Bootstrap 3.4.1 and 4.3.1
+author: mdo
 ---
 
 Today we're shipping [Bootstrap v4.3.1](https://github.com/twbs/bootstrap/releases/tag/v4.3.1) and [v3.4.1](https://github.com/twbs/bootstrap/releases/tag/v3.4.1) to patch an XSS vulnerability, CVE-2019-8331. Also included in v4.3.1 is a small fix to some RFS (responsive font sizes) mixins that were added in v4.3.0.
@@ -14,6 +15,3 @@ Those who have modified the default templates, please [read the new v4.3 sanitiz
 In light of this vulnerability, we're also auditing our security reporting workflows to ensure they're up to date. This will include steps like adding a `SECURITY.md` file to our repository and ensuring our private channels and processes are up to date and documented with the team.
 
 Thank you to [poiu](https://www.drupal.org/u/poiu) for reporting the vulnerability to the [Bootstrap Drupal project](https://www.drupal.org/project/bootstrap) and [Mark Carver](https://www.drupal.org/u/markcarver) from the [Bootstrap Drupal project](https://www.drupal.org/project/bootstrap) for responsibly disclosing the issue to us. Also a massive thank you to [@Johann-S](https://github.com/johann-s), [@Xhmikosr](https://github.com/xhmikosr), and [@bardiharborow](https://github.com/bardiharborow) on our team for the fast turnaround on today's releases.
-
-<3,<br>
-[@mdo](https://twitter.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2019/2019-07-24-lts-plan.md
+++ b/src/_posts/2019/2019-07-24-lts-plan.md
@@ -2,6 +2,7 @@
 layout: post
 title: Introducing our Long Term Support plan
 video: 2HuiH-0R6a0
+author: mdo
 ---
 
 Today we're formally announcing our [Long Term Support plan](https://github.com/twbs/release), a documented approach aimed at strengthening the stability and frequency of releases. As part of this initiative, each major version of Bootstrap will receive at least six months of support after it is retired, followed by six months of critical bug fixes and security updates.
@@ -13,7 +14,3 @@ Bootstrap 4 will move to Long Term Support after we release `v4.4` and will no l
 Bootstrap 5 is under active development. You can follow our progress [on GitHub](https://github.com/twbs/bootstrap).
 
 A special thanks to [@XhmikosR](https://github.com/XhmikosR) for his tireless work in pushing us forward.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2019/2019-11-26-bootstrap-4-4-0.md
+++ b/src/_posts/2019/2019-11-26-bootstrap-4-4-0.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.4.0
 video: P5ZJui3aPoQ
+author: mdo
 ---
 
 Bootstrap 4 has a new update with a handful of feature changes. We’ve had quite the lengthy pull request to add responsive containers—big thanks to the developers who contribute to Bootstrap for sticking with it and helping us along the way. Nearly all new features will be carried forward into Bootstrap 5, so feel free to start using them now.
@@ -30,7 +31,3 @@ We've shipped a lot more in this release, so be sure to check out the [v4.4.0 sh
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2019/2019-11-26-bootstrap-icons.md
+++ b/src/_posts/2019/2019-11-26-bootstrap-icons.md
@@ -2,6 +2,7 @@
 layout: post
 title: Introducing Bootstrap Icons
 video: eM8Ss28zjcE
+author: mdo
 ---
 
 Say hello to [Bootstrap Icons](https://icons.getbootstrap.com/), our very first icon set that's designed entirely by our team and open sourced for everyone to use, with or without Bootstrap. It's still in alpha, but we're incredibly excited to share it with y'all ahead of our v5 alpha.
@@ -17,7 +18,3 @@ I've designed these initial icons in Figma and exported them as SVGs. The plan i
 They're also open sourced under the MIT license, so you're free to download, use, and customize as you need. This is an alpha release for now, so bear with us as we get familiar with creating and managing hundreds of SVGs. and more icons will be added over time.
 
 Head to <https://icons.getbootstrap.com> to explore and download!
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2019/2019-11-28-bootstrap-4-4-1.md
+++ b/src/_posts/2019/2019-11-28-bootstrap-4-4-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.4.1
 video: 2HuiH-0R6a0
+author: mdo
 ---
 
 Today we're shipping [Bootstrap v4.4.1](https://github.com/twbs/bootstrap/releases/tag/v4.4.1)!
@@ -9,7 +10,3 @@ Today we're shipping [Bootstrap v4.4.1](https://github.com/twbs/bootstrap/releas
 In [v4.4.0]({% post_url 2019/2019-11-26-bootstrap-4-4-0 %}), we added `add()` and `subtract()` functions to avoid errors when using zero values in CSS's built in `calc()` function. While these functions work as expected with our build system, which is based on `node-sass`, some alert developers noticed that [things broke when using another Sass compiler](https://github.com/twbs/bootstrap/issues/29743) like Dart Sass or Ruby Sass. To resolve this issue, we've tweaked these functions a bit to output what we would expect.
 
 Lastly, we also added a [theming fix](https://github.com/twbs/bootstrap/pull/29762) for some custom forms in a disabled fieldset.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2019/2019-12-14-bootstrap-icons-alpha2.md
+++ b/src/_posts/2019/2019-12-14-bootstrap-icons-alpha2.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap Icons Alpha 2
 video: HgzGwKwLmgM
+author: mdo
 ---
 
 There's a brand new update of Bootstrap Icons today with our second alpha release! We've updated nearly 20 icons and added over 100 new icons since our last release just a few weeks ago.
@@ -37,7 +38,3 @@ Here's a summary of what's been fixed, updated, or renamed in this release. For 
 ## Get 'em
 
 Alpha 2 has been published to GitHub and npm (package name `bootstrap-icons`). Get your hands on it [from GitHub](https://github.com/twbs/icons/releases), by updating to `v1.0.0-alpha2`, or by snagging the [icons from Figma](https://www.figma.com/file/0xfDVFogWu6g15bVOvBzxS/Bootstrap-Icons-v1.0.0-alpha2).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-03-19-bootstrap-icons-alpha-3.md
+++ b/src/_posts/2020/2020-03-19-bootstrap-icons-alpha-3.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap Icons Alpha 3
 video: kijpcUv-b8M
+author: mdo
 ---
 
 While we continue to work on Bootstrap 5, I've been jamming away on the Bootstrap Icons library, continuing to create as many icons as time allows. Today marks the third alpha, and massive update to the project. We've officially crossed 500 icons!
@@ -31,7 +32,3 @@ Since this is still an alpha, some features are still missing from our docs. Thi
 ## Download
 
 Alpha 3 has been published to GitHub and npm (package name `bootstrap-icons`). Get your hands on it [from GitHub](https://github.com/twbs/icons/releases), by updating to `v1.0.0-alpha3`, or by snagging the [icons from Figma](https://www.figma.com/file/NKZWcfR2T3FU0I7fNLqFvI/Bootstrap-Icons-v1.0.0-alpha3).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-05-12-bootstrap-4-5-0.md
+++ b/src/_posts/2020/2020-05-12-bootstrap-4-5-0.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.5.0
 video: tNG62fULYgI
+author: mdo
 ---
 
 Bootstrap v4.5.0 has landed with dozens of bug fixes, some small new features, and some changes to our development. Originally planned as a v4.4.2 patch release, we've bumped this to a minor release on account of our new features that help bridge the gap between v4 and our upcoming v5.
@@ -26,7 +27,3 @@ We've shipped a lot more in this release, so be sure to check out the [v4.5.0 Gi
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-05-21-bootstrap-icons-alpha4.md
+++ b/src/_posts/2020/2020-05-21-bootstrap-icons-alpha4.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap Icons Alpha 4
 video: 2ZBtPf7FOoM
 date: 2020-05-21 9:30:00
+author: mdo
 ---
 
 We're closing in on 700 icons in Bootstrap Icons with today's release, Alpha 4! We've spent some time under the hood of our build process to improve a few things, added tons of new icons, and fixed some bugs and inconsistencies.
@@ -18,7 +19,3 @@ With 140 new icons in this release, we've almost hit 700 icons. We're likely to 
 ## Download
 
 Alpha 4 has been published to GitHub and npm (package name `bootstrap-icons`). Get your hands on it [from GitHub](https://github.com/twbs/icons/releases), by updating to `v1.0.0-alpha4`, or by snagging the [icons from Figma](https://www.figma.com/file/XDj1VewxEtXzkDDMAvWx2W/Bootstrap-Icons-v1.0.0-alpha4).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-06-16-bootstrap-5-alpha.md
+++ b/src/_posts/2020/2020-06-16-bootstrap-5-alpha.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap 5 alpha!
 video: 3GwjfUFyY6M
 date: 2020-06-16 11:00:00
+author: mdo
 ---
 
 [**Bootstrap 5's very first alpha has arrived!**](https://v5.getbootstrap.com) We've been working hard for several months to refine the work we started in v4, and while we're feeling great about our progress, there's still even more to do.
@@ -216,7 +217,3 @@ Beyond that, keep an eye for more updates to the [Bootstrap Icons](https://icons
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-06-26-bootstrap-icons-alpha5.md
+++ b/src/_posts/2020/2020-06-26-bootstrap-icons-alpha5.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap Icons Alpha 5
 video: HgzGwKwLmgM
 date: 2020-06-26 21:30:00
+author: mdo
 ---
 
 Today we're shipping our fifth and final alpha release of [Bootstrap Icons](https://icons.getbootstrap.com). After today's alpha release, we'll be moving onto final touch ups of existing icons, closing out some more requests, and buttoning things up for a stable v1 release. Stay tuned!
@@ -48,7 +49,3 @@ Beyond that, we'll continue to clean up and improve existing icons and then aim 
 ## Download
 
 Alpha 5 has been published to GitHub and npm (package name `bootstrap-icons`). Get your hands on it [from GitHub](https://github.com/twbs/icons/releases), by updating to `v1.0.0-alpha5`, or by snagging the [icons from Figma](https://www.figma.com/file/hTJtQ2MrMTeNVmYrVBqNZZ/Bootstrap-Icons-v1.0.0-alpha5).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-08-04-bootstrap-4-5-1.md
+++ b/src/_posts/2020/2020-08-04-bootstrap-4-5-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.5.1
 video: iIpfWORQWhU
+author: mdo
 ---
 
 We're shipping our latest patch release today to fix a handful of bugs in Bootstrap 4. While our focus remains on v5's second alpha release (coming in the next couple weeks), we want to keep v4 as stable and reliable as possible.
@@ -70,7 +71,3 @@ After v5's second alpha, we'll be targeting a final alpha before our first beta,
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-08-06-bootstrap-4-5-2.md
+++ b/src/_posts/2020/2020-08-06-bootstrap-4-5-2.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.5.2
 video: ccenFp_3kq8
+author: mdo
 ---
 
 Today's patch release is aimed at addressing some small issues introduced over the last few versions of Bootstrap 4. Read on for details and update when you're ready.
@@ -17,7 +18,3 @@ Today's release rolls back and restores a few things:
 Similarly, **v4.5.1 already removed the `min-width: 0` on `.col`s**. This change was introduced to fix `<pre>` elements not fitting to a column. This an issue with how flexbox works, where a flex container cannot shrink beyond its children's content. Rather than force this on every column, we recommend you apply this as needed with a custom utility. (We'll also aim to add this as a new utility in v5.)
 
 We know this kind of hiccups set you back, so please accept our apologies for the bugs. Be sure to read the referenced pull requests above to get up to speed on what happened and how we fixed it. [This CodePen demo](https://codepen.io/emdeoh/pen/LYNYmPR?editors=1100) has all the known grid issues and fixes implemented in it.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-08-28-bootstrap-icons-stable.md
+++ b/src/_posts/2020/2020-08-28-bootstrap-icons-stable.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap Icons v1.0.0
 video: azdwsXLmrHE
 date: 2020-08-28 21:30:00
+author: mdo
 ---
 
 After five alphas over the last nine months, Bootstrap Icons has officially gone stable with our v1.0.0 release! We're now over 1,100 icons and are on track to add hundreds more in our upcoming minor releases. This has been a labor of love and I'm thrilled to ship this latest update.
@@ -38,7 +39,3 @@ For the Figma users out there, you can also snag the [icons from Figma](https://
 ## Up next
 
 We'll revisit the icon font hopefully in time for our next v1.1.0 release. In addition, there are already another 200+ icons drawn and plans for even more after. We'll continue to fine-tune and iterate on these icons, so keep the feedback and requests coming.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-09-29-bootstrap-5-alpha-2.md
+++ b/src/_posts/2020/2020-09-29-bootstrap-5-alpha-2.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap 5 Alpha 2
 video: Gs069dndIYk
 date: 2020-09-29 11:00:00
+author: mdo
 ---
 
 We're back at it again with a brand new alpha release of Bootstrap 5! Our second alpha has brought some new and improved features, color contrast improvements, improved helpers and utilities, and some documentation design updates.
@@ -95,7 +96,3 @@ npm i bootstrap@next
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-10-13-bootstrap-4-5-3.md
+++ b/src/_posts/2020/2020-10-13-bootstrap-4-5-3.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap 4.5.3
 video: Y3ywicffOj4
+author: mdo
 ---
 
 We've updated Bootstrap 4 with a new patch release to fix some bugs, backport some iterative changes from v5, and more. Enjoy!
@@ -52,7 +53,3 @@ We'll be back to v5 with our third alpha release coming in a couple of weeks. Af
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-10-28-bootstrap-icons-1-1-0.md
+++ b/src/_posts/2020/2020-10-28-bootstrap-icons-1-1-0.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap Icons v1.1.0
 video: 04854XqcfCY
 date: 2020-10-28 21:30:00
+author: mdo
 ---
 
 Our first minor release for Bootstrap Icons is here, with over 30 new icons and a few bug fixes. New icons include fill variations for our emoji icons, including a few new emojis, and several new file type icons.
@@ -38,7 +39,3 @@ You can also [download the release from GitHub](https://github.com/twbs/icons/re
 ## Figma
 
 For the Figma users out there, you can also snag the [icons from Figma](https://www.figma.com/file/6jIgJymnRpMjGSMG2BKNRe/Bootstrap-Icons-v1.1.0?node-id=0%3A1).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-11-11-bootstrap-5-alpha-3.md
+++ b/src/_posts/2020/2020-11-11-bootstrap-5-alpha-3.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap 5 Alpha 3
 video: god7hAPv8f0
 date: 2020-11-11 11:00:00
+author: mdo
 ---
 
 Our third alpha release has landed with tons of updates to our components, utilities, docs, forms, JavaScript, and more. This is a larger alpha release for us and sets us up for our first beta where we'll introduce some final breaking changes and features.
@@ -153,7 +154,3 @@ npm i bootstrap@next
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-12-07-bootstrap-5-beta-1.md
+++ b/src/_posts/2020/2020-12-07-bootstrap-5-beta-1.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap 5 Beta 1
 video: y2bVIBwpCTA
 date: 2020-12-07 11:00:00
+author: mdo
 ---
 
 With our first beta release of Bootstrap 5, we're calling it on new features and breaking changes. From here on out, we're only fine-tuning features, bugs, and documentation on our way to a stable v5 release. Woohoo!
@@ -156,7 +157,3 @@ npm i bootstrap@next
 ## Support the team
 
 Visit our [Open Collective page](https://opencollective.com/bootstrap) or our [team members](https://github.com/orgs/twbs/people)' GitHub profiles to help support the maintainers contributing to Bootstrap.
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-12-11-bootstrap-icons-1-2-0.md
+++ b/src/_posts/2020/2020-12-11-bootstrap-icons-1-2-0.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap Icons v1.2.0
 video: rY0WxgSXdEE
 date: 2020-12-11 21:30:00
+author: mdo
 ---
 
 Our latest Bootstrap Icons release includes dozens of new icons, redesigned documentation, and the most highly requested new feature—icon fonts!
@@ -52,7 +53,3 @@ You can also [download the release from GitHub](https://github.com/twbs/icons/re
 ## Figma
 
 For the Figma users out there, you can also snag the [icons from Figma](https://www.figma.com/file/JeBqM2fRcfIe7wMDgNZG6d/Bootstrap-Icons-v1.2.0?node-id=0%3A1).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-12-12-bootstrap-icons-1-2-1.md
+++ b/src/_posts/2020/2020-12-12-bootstrap-icons-1-2-1.md
@@ -2,6 +2,7 @@
 layout: post
 title: Bootstrap Icons v1.2.1
 date: 2020-12-12 21:30:00
+author: mdo
 ---
 
 Just a quick release to fix a typo in our `package.json` for including the font files in our published package.
@@ -13,7 +14,3 @@ npm i bootstrap-icons
 ```
 
 You can also [download the release from GitHub](https://github.com/twbs/icons/releases/tag/v1.2.1), or [download just the SVGs and fonts](https://github.com/twbs/icons/releases/download/v1.2.1/bootstrap-icons-1.2.1.zip) (without the rest of the repository files).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2020/2020-12-23-bootstrap-icons-1-2-2.md
+++ b/src/_posts/2020/2020-12-23-bootstrap-icons-1-2-2.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap Icons v1.2.2
 video: hFDcoX7s6rE
 date: 2020-12-23 21:30:00
+author: mdo
 ---
 
 We’re ironing out the kinks in our new font files with Bootstrap Icons v1.2.2! We went back to the Figma file and ironed out all the fill-rule details to ensure our SVGs translated into font files properly.
@@ -51,7 +52,3 @@ You can also [download the release from GitHub](https://github.com/twbs/icons/re
 ## Figma
 
 For the Figma users out there, you can also snag the [icons from Figma](https://www.figma.com/file/0fjzjlmwMsHJ0Mgj51j444/Bootstrap-Icons-v1.2.2?node-id=0%3A1).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/_posts/2021-01-07-bootstrap-icons-1-3-0.md
+++ b/src/_posts/2021-01-07-bootstrap-icons-1-3-0.md
@@ -3,6 +3,7 @@ layout: post
 title: Bootstrap Icons v1.3.0
 video: a01QQZyl-_I
 date: 2021-01-07 21:30:00
+author: mdo
 ---
 
 Say hello to over 60 new icons with [Bootstrap Icons v1.3.0](https://icons.getbootstrap.com)! We focused our efforts on filling in some holes and expanding some coverage of a few categories. We’re super happy with how the new additions came out and hope y’all love them, too!
@@ -77,7 +78,3 @@ You can also [download the release from GitHub](https://github.com/twbs/icons/re
 ## Figma
 
 For the Figma users out there, you can also snag the [icons from Figma](https://www.figma.com/file/UuL6jIPhUePmOVttDaQN8h/Bootstrap-Icons-v1.3.0?node-id=0%3A1).
-
-<3,<br>
-
-[@mdo](https://github.com/mdo) & [team](https://github.com/twbs)

--- a/src/index.html
+++ b/src/index.html
@@ -21,16 +21,7 @@ redirect_from:
           </a>
         </h1>
 
-        <div class="d-flex align-items-center mb-4 text-muted">
-          <a class="d-flex align-items-center text-muted text-decoration-none" href="https://github.com/{{ post.author }}" target="_blank" rel="noopener">
-            <img class="mb-0 mr-2" src="https://github.com/{{ post.author }}.png" width="32" height="32" alt="">
-            <span>@{{ post.author }}</span>
-          </a>
-          <span class="d-flex align-items-center ml-3">
-            {% include icons/calendar-event.svg class="mr-2" width="24" height="24" %}
-            {{ post.date | date: '%B %d, %Y' }}
-          </span>
-        </div>
+        {%- include author-info.html -%}
 
         {% if post.video %}
         {%- include video.html do_lazyload=lazyload -%}

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,16 @@ redirect_from:
           </a>
         </h1>
 
-        <span class="post-date">{{ post.date | date_to_string }}</span>
+        <div class="d-flex align-items-center mb-4 text-muted">
+          <a class="d-flex align-items-center text-muted text-decoration-none" href="https://github.com/{{ post.author }}" target="_blank" rel="noopener">
+            <img class="mb-0 mr-2" src="https://github.com/{{ post.author }}.png" width="32" height="32" alt="">
+            <span>@{{ post.author }}</span>
+          </a>
+          <span class="d-flex align-items-center ml-3">
+            {% include icons/calendar-event.svg class="mr-2" width="24" height="24" %}
+            {{ post.date | date: '%B %d, %Y' }}
+          </span>
+        </div>
 
         {% if post.video %}
         {%- include video.html do_lazyload=lazyload -%}

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@ redirect_from:
           </a>
         </h1>
 
-        {%- include author-info.html -%}
+        {%- include author-info.html do_lazyload=lazyload -%}
 
         {% if post.video %}
         {%- include video.html do_lazyload=lazyload -%}


### PR DESCRIPTION
More traditional layout on index and individual posts by having author avatar and name at the top. Also adds an icon from Bootstrap Icons for the date, with a new date format that looks more complete.

<img width="599" alt="Screen Shot 2021-01-09 at 2 00 28 PM" src="https://user-images.githubusercontent.com/98681/104109663-19170880-5285-11eb-9b4d-5dd9a1e05947.png">

Moves all post authors to single authors, to be in the front matter, and removes the `<3, ...` sign-off from all posts.
