### PR TITLE
Fix typo "clases" to "classes"

### DIFF
--- a/src/_posts/2021/2021-01-19-bootstrap-4.6.0.md
+++ b/src/_posts/2021/2021-01-19-bootstrap-4.6.0.md
@@ -22,7 +22,7 @@ Also available in the [v4.6.0 release on GitHub](https://github.com/twbs/bootstr
 
 ### Highlights
 
-- Tooltips and popovers can have custom clases via `customClass` option.
+- Tooltips and popovers can have custom classes via `customClass` option.
 - Added new `.navbar-nav-scroll` class for scrolling expanded navbar contents on mobile devices.
 - For improved accessibiliy, spinners now slow down when `prefers-reduced-motion` is enabled.
 - v4.x docs are now built on Hugo for easier maintenance and backports from v5.x.

--- a/src/_posts/2021/2021-05-05-bootstrap-5.md
+++ b/src/_posts/2021/2021-05-05-bootstrap-5.md
@@ -225,7 +225,7 @@ We've also updated our [starter template](https://getbootstrap.com/docs/5.0/exam
 
 Our grid system and layout options saw some changes to streamline and improve things, namely:
 
-- Column clases can now be used as `width` utilities (e.g., `.col-6` is `width: 50%`) as `padding` is no longer applied outside a `.row`.
+- Column classes can now be used as `width` utilities (e.g., `.col-6` is `width: 50%`) as `padding` is no longer applied outside a `.row`.
 - New gutter utilities can responsively customize horizontal and vertical grid gutters. The gutter width has also been reduced to `1.5rem`.
 - Removed `position: relative` from column classes
 - Dropped the `.media` component for utilities


### PR DESCRIPTION
I'm not sure if you're taking PRs to the blog, but was reading the most recent v5 release post and noticed a small typo. Searched the repo and found one more occurrence that is fixed here.

Fixes typo `clases` to `classes` (two s's)