### PR TITLE
Prevent unused `partials/analytics.html` warning when not in production

### DIFF
--- a/src/layouts/partials/analytics.html
+++ b/src/layouts/partials/analytics.html
@@ -1,1 +1,3 @@
+{{- if hugo.IsProduction }}
 <script async src="https://cdn.usefathom.com/script.js" data-site="{{ .Site.Params.analytics.fathom_site }}"></script>
+{{- end }}

--- a/src/layouts/partials/head.html
+++ b/src/layouts/partials/head.html
@@ -25,6 +25,4 @@
 {{ partial "favicons" . -}}
 {{ partial "social" . -}}
 {{ partial "scripts" . -}}
-{{- if hugo.IsProduction }}
 {{ partial "analytics" . -}}
-{{- end }}


### PR DESCRIPTION
### Description

When running locally this project with `npm run start`, we can see the following warning that is a little bit disturbing:

```
WARN  Template partials/analytics.html is unused, source file /tmp/twbs/blog/src/layouts/partials/analytics.html
```

When not in production mode, the partial file is unused and generates the warning.

I'm aware that maybe we lose some readability with this version, so feel free to close this PR directly without any comments if you prefer to keep the previous version :)

### Testing

* Locally, simply run `npm run start` and the warning is no more present. The `<script>` is not in the dev tools.
* In https://deploy-preview-465--bootstrapblog.netlify.app/, we can find the `<script>` in the dev tools.