### PR TITLE
fix: use Site.Params.main for navbar brand logo link

### DIFF
--- a/src/layouts/partials/navbar.html
+++ b/src/layouts/partials/navbar.html
@@ -2,7 +2,7 @@
   <nav class="container-xxl bd-gutter flex-wrap flex-lg-nowrap" aria-label="Main navigation">
     <div class="d-lg-none" style="width: 2rem;"></div>
 
-    <a class="navbar-brand p-0 me-0 me-lg-2" href="/" aria-label="Bootstrap">
+    <a class="navbar-brand p-0 me-0 me-lg-2" href="{{ .Site.Params.main }}/" aria-label="Bootstrap">
       {{ partial "icons/bootstrap-white-fill.svg" (dict "class" "d-block my-1") -}}
     </a>
 


### PR DESCRIPTION
Currently, the navbar brand logo on the blog subdomain points to the blog's root ("/"). This creates a redundant navigation path since there is already a "Blog" link in the menu. This change updates the logo to point back to the main site (https://getbootstrap.com) using the existing Site.Params.main variable, improving cross-domain navigation consistency.